### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,9 @@ services:
 
   grafana:
     image: grafana/grafana:6.5.0
-#    network_mode: host
-    ports:
-      - 9091:9091
+    network_mode: host
+#    ports:
+#      - 9091:9091
     volumes:
       - ./grafana/provisioning/:/etc/grafana/provisioning/
       - ./grafana/config:/var/lib/grafanaconf
@@ -80,7 +80,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.8.1
-#    network_mode: host
+    network_mode: host
     volumes:
       - ./prometheus/:/etc/prometheus/
       - ./prometheus/storage/:/prometheus/
@@ -89,8 +89,8 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
-    ports:
-      - 9090:9090
+#    ports:
+#      - 9090:9090
     user: "${CURRENT_UID}"
     restart: "unless-stopped"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
 
   grafana:
     image: grafana/grafana:6.5.0
-    network_mode: host
+#    network_mode: host
     ports:
       - 9091:9091
     volumes:
@@ -80,7 +80,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.8.1
-    network_mode: host
+#    network_mode: host
     volumes:
       - ./prometheus/:/etc/prometheus/
       - ./prometheus/storage/:/prometheus/


### PR DESCRIPTION
Due to the new docker-compose syntax, we cannot have `network_mode` and `port` definitions at the same time.

I thus commented the `port` for both `grafana` and `prometheus`. This has been shown to solve Issue #1, i.e., **TEEMon** can be started and function normally, as depicted:

<img width="1125" alt="Screen Shot 2021-03-02 at 3 23 39 PM" src="https://user-images.githubusercontent.com/25379688/109612829-47211680-7b6b-11eb-988c-8986c5b7fe29.png">

Note that commenting the `network_mode` for both `grafana` and `prometheus` does not work, as discuessed in #4.